### PR TITLE
Convert from int to double to avoid auto casting which throws an error on Android

### DIFF
--- a/firestore/lib/src/model/review.dart
+++ b/firestore/lib/src/model/review.dart
@@ -43,7 +43,7 @@ class Review {
     return Review._(
       id: snapshot.id,
       userId: _snapshot['userId'],
-      rating: _snapshot['rating'],
+      rating: _snapshot['rating'].toDouble(),
       text: _snapshot['text'],
       userName: _snapshot['userName'],
       timestamp: _snapshot['timestamp'],


### PR DESCRIPTION

https://stackoverflow.com/questions/58986585/type-int-is-not-a-subtype-of-type-double