### PR TITLE
Update Android app/build.gradle for Vertex AI quickstart.

### DIFF
--- a/vertexai/android/app/build.gradle
+++ b/vertexai/android/app/build.gradle
@@ -22,6 +22,7 @@ if (flutterVersionName == null) {
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 // START: FlutterFire Configuration
 apply plugin: 'com.google.gms.google-services'
 // END: FlutterFire Configuration
@@ -30,12 +31,12 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace "com.example.example"
 
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.example"
-        minSdk 21
-        targetSdk 33
+        minSdk 24
+        targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
- Add kotlin-android plugin to squash com.example.example.MainActivity ClassNotFoundException.
- Update minSdk to 24 to squash Dex exception that emerged after ClassNotFoundException resolved.
- Update target and compile Sdks to 34 (required by latest versions of App Check, Auth, and Core).